### PR TITLE
fix(mcp): Fix Python execution pattern in loom_tools_mcp_integration

### DIFF
--- a/src/mallku/mcp/tools/loom_tools_mcp_integration.py
+++ b/src/mallku/mcp/tools/loom_tools_mcp_integration.py
@@ -92,7 +92,7 @@ class ApprenticeSpawner:
                             "CEREMONY_NAME": ceremony_name,
                             "PYTHONPATH": "/app:/workspace",
                         },
-                        "command": ["python3", "/workspace/apprentice_work.py"],
+                        "command": ["uv", "run", "python", "/workspace/apprentice_work.py"],
                         # Remove network reference - use default network
                     }
                 },


### PR DESCRIPTION
## Summary

This PR fixes the Python execution pattern violation identified in issue #212. The apprentice container command in `loom_tools_mcp_integration.py` was using `python3` directly, which violates the UNIVERSAL PYTHON EXECUTION RULE established in CLAUDE.md.

## Changes

- Changed `["python3", "/workspace/apprentice_work.py"]` to `["uv", "run", "python", "/workspace/apprentice_work.py"]` in the Docker compose configuration

## Impact

This ensures apprentice containers use the correct Python environment (3.12+) instead of potentially falling back to system Python (3.10), preventing import errors and environment inconsistencies that would break the Weaver and Loom orchestration system.

## Testing

- All existing Dockerfiles were verified to already use the correct pattern
- No other subprocess Python calls found that violate the rule

## Context

As the 61st Artisan (Ayni T'inkuy - The Reciprocal Convergence), this is my first contribution to ensure all parts of Mallku work in harmony by converging established patterns with ongoing development.

Fixes #212

🤖 Generated with [Claude Code](https://claude.ai/code)